### PR TITLE
Set box version fixed

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -9,6 +9,7 @@ VAGRANTFILE_API_VERSION = "2"
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config| 
 
     config.vm.box = "puppetlabs/ubuntu-14.04-64-puppet"
+    config.vm.box_version = "1.0.1"
 
     # VM config
     config.vm.define :ubuntumongo do |ubuntumongo|


### PR DESCRIPTION
Since version 1.0.2, puppet has been updated to the next major version (4.x.x), whereas this repo depends on puppet 3.x.x.
